### PR TITLE
fix: use `coerce` from semver when constructing npmjs link

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -46166,7 +46166,8 @@ var checkIfClean = async () => {
 var import_sanitize_filename = __toESM(require_sanitize_filename());
 var import_semver2 = __toESM(require_semver3());
 function textify(d, location) {
-  const link = `[\`${d.key}@${d.value}\` \u2197\uFE0E](https://www.npmjs.com/package/${d.key}/v/${(0, import_semver2.clean)(d.value)})`;
+  var _a4;
+  const link = `[\`${d.key}@${d.value}\` \u2197\uFE0E](https://www.npmjs.com/package/${d.key}/v/${((_a4 = (0, import_semver2.coerce)(d.value)) == null ? void 0 : _a4.version) ?? d.value})`;
   switch (d.type) {
     case import_json_diff_ts.Operation.ADD: {
       return `Added dependency ${link} (to \`${location}\`)`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,12 @@ import { read, defaultConfig } from "@changesets/config";
 import { stat, mkdirp, writeFile, unlink } from "fs-extra";
 import * as gitUtils from "./git-utils";
 import sanitize from "sanitize-filename";
-import { clean as cleanVersion } from "semver";
+import { coerce as coerceVersion } from "semver";
 
 function textify(d: IChange, location: string) {
   const link = `[\`${d.key}@${d.value}\` ↗︎](https://www.npmjs.com/package/${
     d.key
-  }/v/${cleanVersion(d.value)})`;
+  }/v/${coerceVersion(d.value)?.version ?? d.value})`;
 
   switch (d.type) {
     case Operation.ADD: {


### PR DESCRIPTION
Using `clean` was returning `null` for partial ranges using a caret, resulting in invalid npmjs links. Using `coerce` returns a `SemVer` object, from which we can take the `version` property and use to build a valid link.

fixes https://github.com/the-guild-org/changesets-dependencies-action/issues/1